### PR TITLE
Scoped ptr

### DIFF
--- a/base/framework/DeviceComponent.cpp
+++ b/base/framework/DeviceComponent.cpp
@@ -23,7 +23,6 @@
 #include <signal.h>
 #include <sys/signalfd.h>
 #include <dlfcn.h>
-#include <boost/scoped_ptr.hpp>
 
 #include "sca/DeviceComponent.h"
 

--- a/base/include/sca/DeviceComponent.h
+++ b/base/include/sca/DeviceComponent.h
@@ -32,6 +32,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include "CF/DeviceComponent.h"
 #include "CF/CFFullComponentRegistry.h"


### PR DESCRIPTION
Needed to move the include for scoped-ptr up to the header where the first reference to it exists.
